### PR TITLE
Multiple bug fixes and refactoring

### DIFF
--- a/src/classes.js
+++ b/src/classes.js
@@ -1,5 +1,5 @@
 const nspell = require('./deps/nspell/index.js')
-const { cleanText, createClassyElement, css, getRelativeBoundaries } = require('./helpers.js')
+const { cleanText, createClassyElement, css, getRelativeBounds } = require('./helpers.js')
 
 const ID = 'multidict'
 
@@ -20,7 +20,7 @@ class Spelling {
     return this.cleanedText.reduce((acc, word) => {
       if (!this.speller.correct(word)) {
         index = this.content.indexOf(word, index + word.length)
-        acc = acc.concat([new Word(word, ...getRelativeBoundaries(word, this.content, index))])
+        acc = acc.concat([new Word(word, ...getRelativeBounds(word, this.content, index))])
       }
       return acc
     }, [])
@@ -109,7 +109,7 @@ class User {
   }
 }
 
-// A Word is an iterable class that contains a word, its length, and word boundaries
+// A Word is an iterable class that contains some text, its length, and word boundaries
 class Word {
   constructor (word, start, end) {
     this.text = word
@@ -132,16 +132,16 @@ class Word {
 // A WordCarousel is a page/tab agnostic collection of HTML elements that together form a
 // vertically navigatable word carousel inserted into a given node overlaying a specific mark
 class WordCarousel {
-  constructor (node, mark, misspeltWord, suggestedWords) {
+  constructor (node, mark, suggestedWords) {
     this.node = node // an editable HTML node that we assume the user is currently editing
     this.mark = mark // the exact HTML mark to be used to position the word carousel
-    this.misspeltWord = misspeltWord // the misspelt Word that has been marked
     this.suggestedWords = suggestedWords.slice(0, 4) // array of up to 4 words ['word1', 'word2']
     this.acceptedWord = undefined // user chosen word string, can be cleared
     this.currentWord = undefined // active/visible word displayed by carousel
     this.currentSuggestionNode = undefined // active/visible suggestion node displayed by carousel
     this.wordCount = this.suggestedWords.length // amount of words/cells inside the carousel
-    this.opacity = 0 // used to set opacity of inactive/non-visible carousel words
+    this.opacity = this.wordCount > 2 ? 0.3 : 0 // used to set opacity of inactive/non-focused words
+    this.theta = 360 / this.wordCount //
     this.suggestionsIndex = 0 // used to keep track of which suggestion is being shown
     this.suggestionsContainer = createClassyElement('div', [`${ID}-suggestions-container`])
     this.suggestionsFrame = createClassyElement('div', [`${ID}-suggestions-frame`])
@@ -208,8 +208,6 @@ class WordCarousel {
     const words = this.suggestedWords
     const heightOffset = this.suggestionsContainer.offsetHeight
 
-    this.opacity = this.wordCount > 2 ? 0.3 : 0
-    this.theta = 360 / this.wordCount
     this.radius = Math.round((heightOffset / 2) / Math.tan(Math.PI / this.wordCount))
     this.radius = Math.sign(this.radius) < 1 ? 0 : this.radius
 

--- a/src/content.js
+++ b/src/content.js
@@ -1,35 +1,39 @@
-const { debounce, getSelectedWordBoundaries } = require('./helpers.js')
-const { Highlighter } = require('./deps/highlight/highlight.js')
+const {
+  cleanWord, debounce, getCurrentWordBounds, getTextContent, isSupported
+} = require('./helpers.js')
 
-const editableFields = ['TEXTAREA']
+const { Highlighter } = require('./deps/highlight/highlight.js')
 
 let contentPort = null
 let highlighter = null
 let editableNode = null
-let oldValue = ''
+let previousText = ''
 
 // function is debounced on all keyup and click events
 async function edit (event) {
   const target = event.target
-  // don't spellcheck non-editable or unsupported fields
-  if (!editableFields.includes(target.nodeName) || target.contentEditable === false) {
+  const currentText = getTextContent(target, window.location.hostname)
+
+  // don't spellcheck unsupported or uncheckable nodes
+  if (!isSupported(target, window.location)) {
     return
   }
 
   // don't spellcheck if text is identical to last spellchecked text
-  if (target.getAttribute('data-multidict-generated') && (target.value === oldValue)) {
+  if (target.getAttribute('data-multidict-generated') && (currentText === previousText)) {
     return
   }
 
-  // tell background script to connect to active tab if content port undefined
+  // tell background script to connect to active tab if content port falsy
   if (!contentPort) {
     await browser.runtime.sendMessage({ type: 'connectToActiveTab' })
   }
 
-  editableNode = event.target
-  oldValue = editableNode.value
+  // update previousText and editableNode after connecting to current/active tab
+  editableNode = target
+  previousText = currentText
 
-  const detectedLanguage = await browser.i18n.detectLanguage(editableNode.value)
+  const detectedLanguage = await browser.i18n.detectLanguage(currentText)
   const language = detectedLanguage.isReliable
     ? detectedLanguage.languages[0].language
     : 'unreliable'
@@ -37,12 +41,13 @@ async function edit (event) {
   contentPort.postMessage({
     type: 'spellCheck',
     detectedLanguage: language,
-    content: editableNode.value
+    content: currentText
   })
 }
 
 // properly resets all values and cleans up leftover html elements on disconnect event
 function disconnect (p) {
+  console.log('handle disconnect')
   if (p.error) {
     console.warn(`MultiDict: disconnected due to an error: ${p.error.message}. Please try refreshing the page`)
   }
@@ -53,7 +58,7 @@ function disconnect (p) {
   contentPort.onDisconnect.removeListener(disconnect)
   contentPort = null
   highlighter = null
-  oldValue = ''
+  previousText = ''
 }
 
 // handles incoming connections from the background script (port should update with each tab change)
@@ -67,6 +72,7 @@ async function connectionHandler (port, info) {
 
 // handles all incoming messages from the background script
 function messageHandler (message) {
+  let word = message.word
   switch (message.type) {
     case 'highlight':
       if (highlighter && !editableNode.getAttribute('data-multidict-generated')) {
@@ -83,12 +89,13 @@ function messageHandler (message) {
 
     case 'add':
     case 'remove':
+      word = word || getCurrentWordBounds(document.activeElement)[0]
       contentPort.postMessage({
         type: message.type,
-        word: getSelectedWordBoundaries()[0]
+        word: cleanWord(word) // always clean the text before adding/removing custom words
       })
-      // clearing oldValue after add/remove ensures we recheck spelling despite identical content
-      oldValue = ''
+      // clearing previousText after add/remove ensures we recheck spelling despite same content
+      previousText = ''
       break
 
     default:
@@ -96,22 +103,22 @@ function messageHandler (message) {
   }
 }
 
+browser.runtime.onConnect.addListener(connectionHandler)
+
+document.body.addEventListener('keyup', debounce(edit, 700), true)
+document.body.addEventListener('click', debounce(edit, 700), true)
+
 // App Control/Execution Flow
-// 1. Page listeners generate Spellings of currently focused/current editable node content
-// 2. Single Highlighter instance (requires Spelling) attached to focused/current editable node
-// 3. Highlighter instance has own listeners to keep it in sync with editable node and allow user
+// 1. Page listeners generate Spellings of currently focused textarea/editable node content
+// 2. Single Highlighter instance (requires Spelling) attached to textarea/node
+// 3. Highlighter instance has own listeners to keep it in sync with textarea/node and allow user
 //    interaction
 // 4. Highlighter instance generates WordCarousel (suggestions node) as needed and controls the
-//    carousel (WordCarousel does not have own listeners)
+//    carousel (WordCarousel does not have own listeners, is instead driven by Highlighter)
 //
 // Architectural/Design Decisions
 // - Helper functions are Class agnostic (helpers can work with a class instance but never
 //   instantiate or import/require classes.js)
 // - Classes can and do use Helper fuctions/methods during instantiation
-// - All clean text for usage in app should be cleaned using core cleanText helper function (with
-//   or without specific params)
-
-browser.runtime.onConnect.addListener(connectionHandler)
-
-document.body.addEventListener('keyup', debounce(edit, 700))
-document.body.addEventListener('click', debounce(edit, 700))
+// - All spellchecked text and custom words should be cleaned with cleanText/cleanWord helper
+//   functions (with or without specific params)


### PR DESCRIPTION
This has all the bugfixes and refactoring from the add-gmail-support branch but minus the partially working gmail support. Have abandoned gmail support as part of MVP due to lack of interest and wanting to move onto another project - but first wanting to get this published on the browser extension store.

Fix empty textarea throwing exception when trying to set selected word
Change display mode to inline-flex to prevent whitespace being added
Fix suggestions appearing above instead of directly overlayed of word
Apply github domain specific styles
Remove unneeded styling from highlights.css
Finish WordCarousel class and refactoring higlight.js carousel logic
Update Spelling class to generate list of Words (not just strings)
Add higlight.js helper to set currentMarkIndex
Refactor helpers and move them from highlights.js into helpers file
Refactor and update Higlighter to use ES6 class syntax
Optimise content script to only destroy and re-create higlighter if changing editable nodes
Force spelling recheck after adding/removing a word
Fixes switching tabs breaking spell checking
Fixes new tabs not having spell checking
Refactors message sending between background and content script to be more efficient
Update current mark during handle select method of highlight
Reset port to current port after popup closes