### PR TITLE
Chore refactor ports and messaging behaviour

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -45,7 +45,7 @@
     }
   },
 
-  "permissions": ["storage", "contextMenus", "tabs"],
+  "permissions": ["storage", "menus", "tabs"],
 
   "web_accessible_resources": ["dictionaries/*.aff", "dictionaries/*.dic", "media/icons/*.svg"]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,12 @@
       "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
       "dev": true
     },
+    "@types/json5": {
+      "version": "0.0.29",
+      "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
+      "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
+      "dev": true
+    },
     "JSONStream": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
@@ -980,23 +986,24 @@
       }
     },
     "eslint-plugin-import": {
-      "version": "2.20.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.20.2.tgz",
-      "integrity": "sha512-FObidqpXrR8OnCh4iNsxy+WACztJLXAHBO5hK79T1Hc77PgQZkyDGA5Ag9xAvRpglvLNxhH/zSmZ70/pZ31dHg==",
+      "version": "2.21.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.21.1.tgz",
+      "integrity": "sha512-qYOOsgUv63vHof7BqbzuD+Ud34bXHxFJxntuAC1ZappFZXYbRIek3aJ7jc9i2dHDGDyZ/0zlO0cpioES265Lsw==",
       "dev": true,
       "requires": {
-        "array-includes": "^3.0.3",
-        "array.prototype.flat": "^1.2.1",
+        "array-includes": "^3.1.1",
+        "array.prototype.flat": "^1.2.3",
         "contains-path": "^0.1.0",
         "debug": "^2.6.9",
         "doctrine": "1.5.0",
-        "eslint-import-resolver-node": "^0.3.2",
-        "eslint-module-utils": "^2.4.1",
+        "eslint-import-resolver-node": "^0.3.3",
+        "eslint-module-utils": "^2.6.0",
         "has": "^1.0.3",
         "minimatch": "^3.0.4",
-        "object.values": "^1.1.0",
+        "object.values": "^1.1.1",
         "read-pkg-up": "^2.0.0",
-        "resolve": "^1.12.0"
+        "resolve": "^1.17.0",
+        "tsconfig-paths": "^3.9.0"
       },
       "dependencies": {
         "debug": {
@@ -1023,6 +1030,15 @@
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
+        },
+        "resolve": {
+          "version": "1.17.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
+          "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
+          "dev": true,
+          "requires": {
+            "path-parse": "^1.0.6"
+          }
         }
       }
     },
@@ -1660,6 +1676,15 @@
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
       "dev": true
+    },
+    "json5": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+      "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+      "dev": true,
+      "requires": {
+        "minimist": "^1.2.0"
+      }
     },
     "jsonify": {
       "version": "0.0.0",
@@ -2713,6 +2738,18 @@
       "dev": true,
       "requires": {
         "os-tmpdir": "~1.0.2"
+      }
+    },
+    "tsconfig-paths": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.9.0.tgz",
+      "integrity": "sha512-dRcuzokWhajtZWkQsDVKbWyY+jgcLC5sqJhg2PSgf4ZkH2aHPvaOY8YWGhmjb68b5qqTfasSsDO9k7RUiEmZAw==",
+      "dev": true,
+      "requires": {
+        "@types/json5": "^0.0.29",
+        "json5": "^1.0.1",
+        "minimist": "^1.2.0",
+        "strip-bom": "^3.0.0"
       }
     },
     "tslib": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "browserify": "^16.5.1",
     "eslint": "^6.8.0",
     "eslint-config-standard": "^14.1.1",
-    "eslint-plugin-import": "^2.20.2",
+    "eslint-plugin-import": "^2.21.1",
     "eslint-plugin-node": "^9.2.0",
     "eslint-plugin-promise": "^4.2.1",
     "eslint-plugin-standard": "^4.0.1"

--- a/src/background.js
+++ b/src/background.js
@@ -5,7 +5,7 @@ const {
 
 const defaultSettings = ['disableNativeSpellcheck-false']
 
-let user, customWords, contentPort, popupPort, currentPort, customSettings
+let customSettings, customWords, user
 
 // saves a word in browser storage and calls user.addWord
 async function addCustomWord (word) {
@@ -39,7 +39,21 @@ async function removeCustomWord (word) {
   }
 }
 
-// saves user specified extension settings (i.e. from popup) in browser storage
+// get current active tab
+async function getCurrentTab () {
+  const tabs = await browser.tabs.query({ active: true, currentWindow: true })
+  return tabs[0]
+}
+
+// get user specified extension settings from browser storage
+async function getCustomSettings () {
+  customSettings = await browser.storage.sync.get('settings')
+  customSettings = Array.isArray(customSettings.settings)
+    ? updateSettingsObject(customSettings.settings)
+    : updateSettingsObject(defaultSettings)
+}
+
+// saves user specified extension settings (i.e. from popup) to browser storage
 async function saveSettings (message) {
   const error = await browser.storage.sync.set({ settings: message.settings })
 
@@ -50,38 +64,47 @@ async function saveSettings (message) {
   }
 }
 
-const getCustomWords = () => currentPort.postMessage({ type: 'getCustomWords', customWords })
-const getCustomSettings = () => currentPort.postMessage({ type: 'getCustomSettings', customSettings })
+// respond to the sender with an object containing message content and type
+function respond (sender, content, type) {
+  console.log('type', type)
+  console.log('content', content)
+  console.log('sender', sender)
+  if (sender.tab) {
+    browser.tabs.sendMessage(sender.tab.id, { type, content })
+  } else if (sender.name === 'popup') {
+    sender.postMessage({ type, content })
+  } else {
+    console.warn('MultiDict: unrecognized sender structure. Cannot respond to sender:', sender)
+  }
+}
 
 // checks content for spelling errors and returns a new Spelling instance
 function spellCheck (message) {
   const lang = user.getPreferredLanguage(message.detectedLanguage)
-  contentPort.postMessage({
-    type: 'highlight',
-    spelling: new Spelling(user.spellers[lang], message.content)
-  })
+  return new Spelling(user.spellers[lang], message.content)
 }
 
-// api that handles performing all actions - core function should only ever be called by the api
-function api (message) {
+// api that handles performing all actions - background functions should only ever be called by api
+// api always cleans the text before adding/removing custom words
+function api (message, sender) {
   switch (message.type) {
-    // api always clean the text before adding/removing custom words
     case 'add':
       addCustomWord(cleanWord(message.word))
-      contentPort.postMessage({ type: 'refresh' })
+        .then(() => respond(sender, null, 'refresh'))
       break
     case 'remove':
       removeCustomWord(cleanWord(message.word))
-      contentPort.postMessage({ type: 'refresh' })
+        .then(() => respond(sender, null, 'refresh'))
       break
     case 'spellCheck':
-      spellCheck(message)
+      respond(sender, spellCheck(message), 'highlight')
       break
     case 'getCustomWords':
-      getCustomWords()
+      respond(sender, customWords, 'getCustomWords')
       break
     case 'getCustomSettings':
       getCustomSettings()
+        .then(() => respond(sender, customSettings, 'getCustomSettings'))
       break
     case 'saveSettings':
       saveSettings(message)
@@ -92,17 +115,11 @@ function api (message) {
 }
 
 // listens to all incoming messages from the popup/action menu and handle popup closing
-async function popupListener (port) {
-  if (!contentPort) {
-    await connectToActiveTab()
-  }
-
-  popupPort = port
-  currentPort = port
-
-  if (popupPort.name === 'popup') {
+function popupListener (popupPort) {
+  if (!popupPort.onMessage.hasListener(api)) {
     popupPort.onMessage.addListener(api)
     popupPort.onDisconnect.addListener(() => {
+      // remove listener and cleanup popupPort when popup closed
       popupPort.onMessage.removeListener(api)
       popupPort = null
     })
@@ -110,42 +127,27 @@ async function popupListener (port) {
 }
 
 // listens to all incoming commands (keyboard shortcuts) and context menu messages
-async function commandAndContextListener (info) {
+async function commandAndMenuListener (info, tab) {
   const command = info.menuItemId || info
-  if (!contentPort) {
-    await connectToActiveTab()
-  }
-  if (command === 'add' || command === 'remove') {
-    contentPort.postMessage({ type: command, word: info.selectionText })
-  }
-}
-
-// listen to incoming messages from the content script and on new tab creation
-async function connectToActiveTab () {
-  let tab = await browser.tabs.query({ active: true, currentWindow: true })
-  tab = tab[0]
-  const tabName = `tab-${tab.id}`
-
-  if (contentPort) {
-    contentPort.onMessage.removeListener(api)
-    contentPort.disconnect()
-    contentPort = null
+  // tab parameter is blank when shortcut keys are used to add or remove a word
+  if (!tab) {
+    tab = await getCurrentTab
   }
 
-  contentPort = browser.tabs.connect(tab.id, { name: tabName })
-  contentPort.onMessage.addListener(api)
-  currentPort = contentPort
+  // when using shortcuts or context menu, we add/remove words via the content script
+  // this enables the user to define a keyboard shortcut to trigger add/remove which will smartly
+  // detect the word based on selection or cursor position on the currently active tab
+  if (tab && command) {
+    respond({ tab }, { word: info.selectionText }, command)
+  } else {
+    console.warn(`MultiDict: Command ${command} failed. Tab info:`, tab)
+  }
 }
 
 // load dictionaries, create langauges from browser acceptLanguages, and instantiate user
 async function main () {
   const languages = prepareLanguages(await browser.i18n.getAcceptLanguages())
   const dictionariesAndPrefs = await loadDictionariesAndPrefs(languages)
-
-  customSettings = await browser.storage.sync.get('settings')
-  customSettings = Array.isArray(customSettings.settings)
-    ? updateSettingsObject(customSettings.settings)
-    : updateSettingsObject(defaultSettings)
 
   customWords = await browser.storage.sync.get('personal')
   customWords = Array.isArray(customWords.personal) ? customWords.personal : []
@@ -159,13 +161,14 @@ async function main () {
   console.log('settings', customSettings)
 }
 
+browser.commands.onCommand.addListener(commandAndMenuListener)
+browser.menus.onClicked.addListener(commandAndMenuListener)
+browser.runtime.onMessage.addListener(api)
+browser.runtime.onConnect.addListener(popupListener)
+
 main()
 
-browser.commands.onCommand.addListener(commandAndContextListener)
-browser.contextMenus.onClicked.addListener(commandAndContextListener)
-browser.tabs.onCreated.addListener(connectToActiveTab)
-browser.runtime.onMessage.addListener(connectToActiveTab)
-browser.runtime.onConnect.addListener(popupListener)
+// browser.tabs.onCreated.addListener(connectToActiveTab)
 
 // Goal: enable multiple laguages to be used when spell checking by detecting content language
 //

--- a/src/classes.js
+++ b/src/classes.js
@@ -152,7 +152,7 @@ class WordCarousel {
 
   showSuggestions () {
     this.suggestionsWrapper.visibility = null
-    this.node.style.filter = 'blur(2px)'
+    this.node.style.filter = 'blur(1px)'
     this.mark.style.visibility = 'hidden'
   }
 

--- a/src/deps/highlight/highlight.js
+++ b/src/deps/highlight/highlight.js
@@ -218,7 +218,7 @@ class Highlighter {
   storeSelection (currentNode) {
     const selection = window.getSelection()
     const selectionBounds = getSelectionBounds(currentNode)
-    const selectionRange = selection.getRangeAt(0) || null
+    const selectionRange = selection.rangeCount > 0 ? selection.getRangeAt(0) : null
     const storedRange = {}
 
     if (selectionRange) {

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -93,7 +93,7 @@ function createClassyElement (type, classes) {
 
 // create Add and Remove multdict context menu items
 function createMenuItems () {
-  browser.contextMenus.create({
+  browser.menus.create({
     id: 'add',
     type: 'normal',
     title: 'Add word to personal dictionary',
@@ -101,7 +101,7 @@ function createMenuItems () {
     icons: { 16: 'media/icons/plus-icon.svg' }
   })
 
-  browser.contextMenus.create({
+  browser.menus.create({
     id: 'remove',
     type: 'normal',
     title: 'Remove word from personal dictionary',
@@ -251,7 +251,7 @@ function getRelativeBounds (word, content, startIndex) {
 // selection are relative to the text within the specified node
 function getSelectionBounds (node) {
   // textareas are easy - just return the selectionStart and selectionEnd properties
-  if (node.nodeName === 'TEXTAREA' && node.selectionStart && node.selectionEnd) {
+  if (node.nodeName === 'TEXTAREA') {
     return { start: node.selectionStart, end: node.selectionEnd }
   }
 

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -98,11 +98,11 @@ function handleOptions (e) {
 // listen to incoming messages from background script
 messageHandler.onMessage.addListener((message) => {
   if (message.type === 'getCustomWords') {
-    populateList(document.querySelector('.words'), message.customWords)
+    populateList(document.querySelector('.words'), message.content)
   }
 
   if (message.type === 'getCustomSettings') {
-    populateOptions(document.querySelector('.options'), message.customSettings)
+    populateOptions(document.querySelector('.options'), message.content)
   }
 })
 

--- a/web-ext-config.js
+++ b/web-ext-config.js
@@ -8,6 +8,7 @@ module.exports = {
     startUrl: [
       'about:debugging',
       'about:preferences',
+      'file:///home/grayedfox/github/multi-dict/test_page/test-page.html',
       'file:///home/grayedfox/github/multi-dict/test_page/test-page.html'
     ]
   },


### PR DESCRIPTION
Use single message instances for content and background communication
Use menus instead of context menus api
Fix spell checker breaking on page refresh
Fix spell checker not working when caret places at 1st position of text area
Refactor content script to call specific methods instead of bundling different logic inside the message handler
Fix disableNativeSpell check not being applied to text areas on initial page load
Update blur factor of highlighter to be 1px instead of 2px
Update es-lint dependency